### PR TITLE
Add seperate getCount function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,5 +37,21 @@ var_dump($pp->isInsecure('password', 5));
 ```
 The method will now return true if it has been found in the PwnedPasswords API more than 5 times.
 
+
+If you want to build your own thresholds (Ex. display a warning if the password has been found more than once and an error if more than 5x) you can call the `isInsecure` method like below.
+```php
+<?php
+
+require_once('vendor/autoload.php');
+
+$pp = new PwnedPasswords\PwnedPasswords;
+
+$count = $pp->getCount('password');
+
+var_dump($count);
+```
+The method will return the amount the password has been found in the PwnedPasswords API.
+
+
 # Issues
 Please feel free to use the Github issue tracker to post any issues you have with this library.

--- a/src/PwnedPasswords/PwnedPasswords.php
+++ b/src/PwnedPasswords/PwnedPasswords.php
@@ -6,7 +6,7 @@ class PwnedPasswords
 {
     protected $apiURL = 'https://api.pwnedpasswords.com';
 
-    public function isInsecure($password, $maxUsage = 1)
+    public function getCount($password)
     {
         // We need to get the SHA1 of the password first before we send it to the Pwned Passwords API.
         $passwordHash = strtoupper(sha1($password));
@@ -16,7 +16,7 @@ class PwnedPasswords
 
         // Now we can fire it off to the API.
         $apiURL = $this->apiURL . '/range/' . $passwordPrefix;
-        $ch     = curl_init($apiURL);
+        $ch = curl_init($apiURL);
 
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
@@ -35,15 +35,18 @@ class PwnedPasswords
 
             // Check the password hash and see if it matches.
             if ($testHash === $passwordHash) {
-                // The password has been found in the list. Now let's examine if it's been used more than our threshold allows.
-                if (intval($passwordLine[1]) > $maxUsage) {
-                    return true;
-                }
-
-                return false;
+                // The password has been found in $passwordArray - Return the amount
+                return intval($passwordLine[1]);
             }
         }
 
-        return false;
+        // Our password hasn't been included.
+        return 0;
+    }
+
+    public function isInsecure($password, $maxUsage = 1)
+    {
+        // This is just a shorthand to remain backwards compatible. Calls the getCount function and compares the result with $maxUsage
+        return (self::getCount($password) > $maxUsage);
     }
 }


### PR DESCRIPTION
This change allows developers to build their own thresholds into their application, for example displaying an error if the password has been found once and a warning if it was found more than 5x without sending multiple requests to the API. Tested & backwards compatible